### PR TITLE
Make search case-insensitive

### DIFF
--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -54,7 +54,7 @@ private
   def search_records(records)
     if params[:sSearch].present?
       query = @searchable_columns.map do |column|
-        "#{column} LIKE :search"
+        "#{column} ILIKE :search"
       end.join(" OR ")
       records = records.where(query, search: "%#{params[:sSearch]}%")
     end

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -11,7 +11,7 @@ class AjaxDatatablesRails
   def initialize(view)
     @view = view
     db_adapter = ActiveRecord::Base.configurations[Rails.env]['adapter']
-    @search_query_method = db_adapter == 'postgresql' ? 'ILIKE' : 'LIKE'
+    @search_query_method = db_adapter.match('postgres') ? 'ILIKE' : 'LIKE'
   end
 
   def method_missing(meth, *args, &block)

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -10,6 +10,8 @@ class AjaxDatatablesRails
 
   def initialize(view)
     @view = view
+    db_adapter = ActiveRecord::Base.configurations[Rails.env]['adapter']
+    @search_query_method = db_adapter == 'postgresql' ? 'ILIKE' : 'LIKE'
   end
 
   def method_missing(meth, *args, &block)
@@ -54,7 +56,7 @@ private
   def search_records(records)
     if params[:sSearch].present?
       query = @searchable_columns.map do |column|
-        "#{column} ILIKE :search"
+        "#{column} #{@search_query_method} :search"
       end.join(" OR ")
       records = records.where(query, search: "%#{params[:sSearch]}%")
     end


### PR DESCRIPTION
Hi, I think most people would prefer a case-insensitive search (since users rarely bother to capitalize search terms).   All I've done is change the LIKE query to ILIKE.

Cheers,
Garrett

P.S.  Great gem, by the way; definitely saved me a good bit of time :)
