### PR TITLE
Corrected usage example, case-insensitive query

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -6,7 +6,7 @@
 # First we specify our desired <ruby>[@<gemset>], the @gemset name is optional,
 # Only full ruby name is supported here, for short names use:
 #     echo "rvm use 1.9.3" > .rvmrc
-environment_id="ruby-1.9.3-p125@ajax-datatables-rails"
+environment_id="ruby-1.9.3-p194@ajax-datatables-rails"
 
 # Uncomment the following lines if you want to verify rvm version per project
 # rvmrc_rvm_version="1.11.0-pre" # 1.10.1 seams as a safe start

--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ def get_raw_records
 end
 ```
 
-This is where your query goes.
+This is where your query goes. For instance, if you want to show all users:
 
 ```ruby
 def get_raw_records
-  User.all
+  User
 end
 ```
+
+Do not put `User.all` as this will convert to an array, and give you an error
+because the `offset` and `limit` methods are not defined for an array.
 
 ### Controller
 Set up the controller to respond to JSON

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -1,11 +1,11 @@
 # require 'rails'
 
 class AjaxDatatablesRails
-  
+
   class MethodError < StandardError; end
 
   VERSION = '0.0.1'
-    
+
   attr_reader :columns, :model_name, :searchable_columns
 
   def initialize(view)
@@ -38,9 +38,9 @@ private
   def filtered_record_count
     search_records(get_raw_records).count
   end
-  
+
   def fetch_records
-    search_records(sort_records(paginate_records(get_raw_records)))
+    paginate_records(search_records(sort_records(get_raw_records)))
   end
 
   def paginate_records(records)

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -55,7 +55,7 @@ private
     if params[:sSearch].present?
       search_param = params[:sSearch].strip
       query = @searchable_columns.map do |column|
-        "#{column} ILIKE :search"
+        "LOWER(#{column}) LIKE LOWER(:search)"
       end.join(" OR ")
       records = records.where(query, search: "%#{search_param}%")
     end

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -53,10 +53,11 @@ private
 
   def search_records(records)
     if params[:sSearch].present?
+      search_param = params[:sSearch].strip
       query = @searchable_columns.map do |column|
-        "#{column} LIKE :search"
+        "#{column} ILIKE :search"
       end.join(" OR ")
-      records = records.where(query, search: "%#{params[:sSearch]}%")
+      records = records.where(query, search: "%#{search_param}%")
     end
     return records
   end


### PR DESCRIPTION
I couldn't get this to work correctly for me with Postgres and ActiveRecord 3.2.8 because I was getting an error:

```
undefined method 'offset' in <Array...>
```

This was because in my `get_raw_records` method I was doing as you suggested in the README:

```
def get_raw_records
  User.all
end
```

Instead, it should read:

```
def get_raw_records
  User
end
```

Also, I found stripping whitespace and making the query case-insensitive (with ILIKE) helped the user interface feel more obvious to users.
