### PR TITLE
Support for single-column searching

### DIFF
--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -65,7 +65,8 @@ private
       search_condition(column, value) if value.present?
     end
     conditions = conditions.compact.reduce(:and)
-    records.where(conditions)
+    records = records.where(conditions) if conditions.present?
+    records
   end
 
   def search_condition(column, value)

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -70,7 +70,11 @@ private
 
   def search_condition(column, value)
     column = column.split('.').last
-    @model_name.arel_table[column].matches("%#{value}%")
+    column_hash = @model_name.columns_hash[column]
+    if column_hash && [:string, :text].include?(column_hash.type)
+      return @model_name.arel_table[column].matches("%#{value}%")
+    end
+    @model_name.arel_table[column].eq(value)
   end
 
   def page

--- a/lib/ajax-datatables-rails.rb
+++ b/lib/ajax-datatables-rails.rb
@@ -58,6 +58,10 @@ private
       end.join(" OR ")
       records = records.where(query, search: "%#{params[:sSearch]}%")
     end
+    @columns.each_with_index do |column, index|
+      query = params[:"sSearch_#{index}"]
+      records = records.where("#{column} LIKE ?", query) unless query.blank?
+    end
     return records
   end
 


### PR DESCRIPTION
Thanks for making this; it's been very useful!

I noticed that there wasn't support for single-column searching, which I needed, so I've added it in.

To save you from digging through [the docs](http://www.datatables.net/api): `fnFilter` optionally takes a second argument that specifies the column which the search should target (e.g. `myTable.fnFilter('my search', 3)`), and this adds support for that.
