### PR TITLE
Added ability to use modules in searchable method

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -92,7 +92,11 @@ module AjaxDatatablesRails
 
     def search_condition(column, value)
       model, column = column.split('.')
-      model = model.singularize.titleize.gsub( / /, '' ).constantize
+      if model.scan('/').any?
+        model = model.singularize.gsub( / /, '' ).classify.constantize
+      else
+        model = model.singularize.titleize.gsub( / /, '' ).constantize
+      end
       model.arel_table[column.to_sym].matches("%#{value}%")
     end
 


### PR DESCRIPTION
This PR gives you the ability to reference Models from Rails Engines / Modules.

For example:

def searchable_columns
    # list columns inside the Array in string dot notation.
    # Example: 'users.email'
    @searchable_columns ||= [
       "module_or_engine_name/model_name.column_name",
    ]
end

The sortable method seems to work fine using the normal notation (module_or_engine_name_model_name.column_name)
