### PR TITLE
Fix count method to work with select statement for Rails 4.1

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -36,8 +36,8 @@ module AjaxDatatablesRails
     def as_json(options = {})
       {
         :draw => params[:draw].to_i,
-        :recordsTotal =>  get_raw_records.count,
-        :recordsFiltered => filter_records(get_raw_records).count,
+        :recordsTotal =>  get_raw_records.count(:all),
+        :recordsFiltered => filter_records(get_raw_records).count(:all),
         :data => data
       }
     end


### PR DESCRIPTION
Changes in Rails 4.1 prevents .count from working when you do something like `User.select("id, name").count` which would generate the SQL: `SELECT COUNT(id, name) FROM users;` which gives an error.

One work around I found was instead calling `User.select("id, name").count(:all)` which generates the SQL `SELECT COUNT(*) FROM users;` which works.
