### PR TITLE
fix AjaxDatabaseRails::base#search_condition for namespaced model

### DIFF
--- a/ajax-datatables-rails.gemspec
+++ b/ajax-datatables-rails.gemspec
@@ -19,12 +19,14 @@ Gem::Specification.new do |gem|
   gem.require_path = "lib"
 
   gem.add_dependency 'railties',   '>= 3.1'
-  
+
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "generator_spec"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
-  
+  gem.add_development_dependency "activerecord", "~> 4.l.6"
+  gem.add_development_dependency "sqlite3"
+
   if RUBY_VERSION == '1.9.2'
     gem.add_development_dependency "rails", "3.1.0"
   else

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -104,7 +104,11 @@ module AjaxDatatablesRails
 
     def search_condition(column, value)
       model, column = column.split('.')
-      model = model.singularize.titleize.gsub( / /, '' ).constantize
+      if model.scan("_").any?
+        model = model.singularize.titleize.gsub( / /, '::' ).constantize
+      else
+        model = model.singularize.titleize.gsub( / /, '' ).constantize
+      end
 
       casted_column = ::Arel::Nodes::NamedFunction.new('CAST', [model.arel_table[column.to_sym].as(typecast)])
       casted_column.matches("%#{value}%")
@@ -139,12 +143,12 @@ module AjaxDatatablesRails
     end
 
     def sort_column(item)
-      sortable_columns[item['column'].to_i]
+      sortable_columns[item[:column].to_i]
     end
 
     def sort_direction(item)
       options = %w(desc asc)
-      options.include?(item['dir']) ? item['dir'].upcase : 'ASC'
+      options.include?(item[:dir]) ? item[:dir].upcase : 'ASC'
     end
   end
 end

--- a/spec/ajax-datatables-rails/kaminari_spec.rb
+++ b/spec/ajax-datatables-rails/kaminari_spec.rb
@@ -18,14 +18,14 @@ describe KaminariDatatable do
     let(:records) { users_database.all }
 
     it 'calls #page on passed record collection' do
-      records.should_receive(:page)
+      expect(records).to receive(:page)
       datatable.send(:paginate_records, records)
     end
 
     it 'calls #per_page on passed record collection' do
       arry = double('Array', :per => [])
-      records.stub(:page).and_return(arry)
-      arry.should_receive(:per)
+      allow(records).to receive(:page).and_return(arry)
+      expect(arry).to receive(:per)
       datatable.send(:paginate_records, records) 
     end
   end

--- a/spec/ajax-datatables-rails/simple_paginator_spec.rb
+++ b/spec/ajax-datatables-rails/simple_paginator_spec.rb
@@ -18,14 +18,14 @@ describe SimplePaginateDatatable do
     let(:records) { users_database.all }
 
     it 'calls #offset on passed record collection' do
-      records.should_receive(:offset)
+      expect(records).to receive(:offset)
       datatable.send(:paginate_records, records)
     end
 
     it 'calls #limit on passed record collection' do
       arry = double('Array', :limit => [])
-      records.stub(:offset).and_return(arry)
-      arry.should_receive(:limit)
+      allow(records).to receive(:offset).and_return(arry)
+      expect(arry).to receive(:limit)
       datatable.send(:paginate_records, records) 
     end
   end

--- a/spec/ajax-datatables-rails/will_paginate_spec.rb
+++ b/spec/ajax-datatables-rails/will_paginate_spec.rb
@@ -18,7 +18,7 @@ describe WillPaginateDatatable do
     let(:records) { users_database.all }
 
     it 'calls #page and #per_page on passed record collection' do
-      records.should_receive(:paginate).with(:page=>1, :per_page=>10)
+      expect(records).to receive(:paginate).with(:page=>1, :per_page=>10)
       datatable.send(:paginate_records, records)
     end
   end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -1,0 +1,17 @@
+class User < ActiveRecord::Base
+end
+
+class UserData < ActiveRecord::Base
+end
+
+module Statistics
+  def self.table_name_prefix
+    "statistics_"
+  end
+end
+
+class Statistics::Request < ActiveRecord::Base
+end
+
+class Statistics::Session < ActiveRecord::Base
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,0 +1,29 @@
+ActiveRecord::Schema.define do
+  self.verbose = false
+
+  create_table :users, :force => true do |t|
+    t.string :username
+
+    t.timestamps
+  end
+
+  create_table :user_data, :force => true do |t|
+    t.string :address
+
+    t.timestamps
+  end
+
+
+  create_table :statistics_requests, :force => true do |t|
+    t.string :baz
+
+    t.timestamps
+  end
+
+  create_table :statistics_sessions, :force => true do |t|
+    t.string :foo
+    t.integer :bar
+
+    t.timestamps
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
 require 'pry'
 require 'rails'
+require 'active_record'
 require 'ajax-datatables-rails'
+
+ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+
+load File.dirname(__FILE__) + '/schema.rb'
+require File.dirname(__FILE__) + '/models.rb'


### PR DESCRIPTION
today i got an error when doing searching 
after tracing rails log, its because #search_condition method replace " " with "" 
this is the case 
let say my model is Statistics::Request with table name "statistics_requests" 
so it will converted to `"statistics_requests"` -> `"statistics_request"` -> `"Statistics Request"` -> `"StatisticsRequest"` 
that's why my model not found

but i'm using activerecord at rspec, you may drop this and back using regular class
and i have changed rspec syntax to latest rspec syntax using transpec gem to remove rspec deprecated syntax
