### PR TITLE
Allow disabling of columns orderable to play nice with sortable_columns

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -139,12 +139,25 @@ module AjaxDatatablesRails
     end
 
     def sort_column(item)
-      sortable_columns[item['column'].to_i]
+      sortable_columns[sortable_diplayed_columns.index(item[:column])]
     end
 
     def sort_direction(item)
       options = %w(desc asc)
       options.include?(item['dir']) ? item['dir'].upcase : 'ASC'
     end
+
+    def sortable_diplayed_columns
+      @sortable_diplayed_columns ||= generate_sortable_diplayed_columns
+    end
+
+    def generate_sortable_diplayed_columns
+      @sortable_diplayed_columns = []
+      params[:columns].each_value do |column|
+        @sortable_diplayed_columns << column[:data] if column[:orderable] == 'true'
+      end
+      @sortable_diplayed_columns
+    end
+
   end
 end

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -139,7 +139,7 @@ module AjaxDatatablesRails
     end
 
     def sort_column(item)
-      sortable_columns[sortable_diplayed_columns.index(item[:column])]
+      sortable_columns[sortable_displayed_columns.index(item[:column])]
     end
 
     def sort_direction(item)
@@ -147,16 +147,16 @@ module AjaxDatatablesRails
       options.include?(item['dir']) ? item['dir'].upcase : 'ASC'
     end
 
-    def sortable_diplayed_columns
-      @sortable_diplayed_columns ||= generate_sortable_diplayed_columns
+    def sortable_displayed_columns
+      @sortable_displayed_columns ||= generate_sortable_displayed_columns
     end
 
-    def generate_sortable_diplayed_columns
-      @sortable_diplayed_columns = []
+    def generate_sortable_displayed_columns
+      @sortable_displayed_columns = []
       params[:columns].each_value do |column|
-        @sortable_diplayed_columns << column[:data] if column[:orderable] == 'true'
+        @sortable_displayed_columns << column[:data] if column[:orderable] == 'true'
       end
-      @sortable_diplayed_columns
+      @sortable_displayed_columns
     end
 
   end


### PR DESCRIPTION
Take an example, there is a table with 6 columns. The first 4 columns are searchable/orderable, as is the 6th. The 5th column displayed on the table is just a link, or some other data that doesn't need ordered. So there are 5 orderable columns and 6 columns displayed.

```
def sortable_columns
    # list columns inside the Array in string dot notation.
    # Example: 'users.email'
    @sortable_columns ||= ["training_search_entries.name",
                          "training_search_entries.date_and_time",
                          "training_search_entries.location",
                          "training_search_entries.spots",
                          "training_search_entries.status"
                          ]
  end

  def searchable_columns
    # list columns inside the Array in string dot notation.
    # Example: 'users.email'
    @searchable_columns ||= ["training_search_entries.name",
                          "training_search_entries.date_and_time",
                          "training_search_entries.location",
                          "training_search_entries.spots",
                          "training_search_entries.status"
                          ]
  end
```

If one makes the 5th column not orderable through the DataTables API - https://datatables.net/reference/option/columns.orderable

EX: 

```
"columnDefs": [
    { "orderable": false, "targets": 4 }
  ]
```

![image](https://cloud.githubusercontent.com/assets/4645899/5927482/bcbc7f76-a640-11e4-952f-583a5bbea82a.png)

Then when clicking on the 6th column to order it, it tries to find the 6th orderable column, but there is none, so it generates a faulty query.

This PR remedies this by identify from the params which columns have not had their ordering shut off with the DataTables API and uses that to correctly identify which column the user is trying to sort by.
