### PR TITLE
Should also handle hash keys

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -177,7 +177,7 @@ module AjaxDatatablesRails
     end
 
     def new_sort_column(item)
-      model, column = sortable_columns[sortable_displayed_columns.index(item[:column])].split('.')
+      model, column =  sortable_columns[item[:column].to_i].split('.')
       col = [model.constantize.table_name, column].join('.')
     end
 


### PR DESCRIPTION
  When using hash instead of array to feed data to DT, we use the hash keys
  in datatable settings. So datatable on its sort query will be sending those
  hash keys instead of the array index.
