### PR TITLE
handling hash -   Removes dependency on array index from datatable

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -172,12 +172,16 @@ module AjaxDatatablesRails
       deprecated_sort_column(item)
     end
 
+    def sortable_columns_hash
+      ( sortable_columns.is_a? Array) ? Hash[sortable_columns.map.with_index { |i, x| [x.to_s, i] }] : sortable_columns
+    end
+
     def deprecated_sort_column(item)
-      sortable_columns[sortable_displayed_columns.index(item[:column])]
+      sortable_columns_hash[sortable_displayed_columns[item[:column]]]
     end
 
     def new_sort_column(item)
-      model, column =  sortable_columns[item[:column].to_i].split('.')
+      model, column = sortable_columns_hash[sortable_displayed_columns[item[:column]]].split('.')
       col = [model.constantize.table_name, column].join('.')
     end
 
@@ -191,9 +195,9 @@ module AjaxDatatablesRails
     end
 
     def generate_sortable_displayed_columns
-      @sortable_displayed_columns = []
-      params[:columns].each_value do |column|
-        @sortable_displayed_columns << column[:data] if column[:orderable] == 'true'
+      @sortable_displayed_columns = {}
+      params[:columns].each do |key,column|
+        @sortable_displayed_columns[key] = column[:data] if column[:orderable] == 'true'
       end
       @sortable_displayed_columns
     end

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -177,7 +177,7 @@ module AjaxDatatablesRails
     end
 
     def new_sort_column(item)
-      model, column = sortable_columns[sortable_displayed_columns.index(item[:column])].split('.')
+      model, column =  sortable_columns[item[:column].to_i].split('.')
       col = [model.constantize.table_name, column].join('.')
     end
 

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -158,7 +158,7 @@ module AjaxDatatablesRails
 
     def generate_searchable_columns
       @searchable_columns_from_dt_view = {}
-      params[:columns].each do |index, column|
+      params[:columns].to_a.each do |index, column|
         @searchable_columns_from_dt_view[index] = column[:data] unless column[:search][:value].blank?
       end
       @searchable_columns_from_dt_view
@@ -215,7 +215,7 @@ module AjaxDatatablesRails
 
     def generate_sortable_displayed_columns
       @sortable_displayed_columns = {}
-      params[:columns].each do |key,column|
+      params[:columns].to_a.each do |key,column|
         @sortable_displayed_columns[key] = column[:data] if column[:orderable] == 'true'
       end
       @sortable_displayed_columns

--- a/spec/ajax-datatables-rails/ajax_datatables_rails_spec.rb
+++ b/spec/ajax-datatables-rails/ajax_datatables_rails_spec.rb
@@ -76,17 +76,40 @@ describe AjaxDatatablesRails::Base do
     end
 
     describe '#sort_column' do
-      it 'returns a column name from the #sorting_columns array' do
+      it 'returns a column name from the #sorting_columns hash' do
         sort_view = double(
           'view', :params => params
         )
         datatable = AjaxDatatablesRails::Base.new(sort_view)
-        allow(datatable).to receive(:sortable_displayed_columns) { ["0", "1"] }
+        allow(datatable).to receive(:sortable_displayed_columns) { {"0"=>"0", "1"=> "1"} }
         allow(datatable).to receive(:sortable_columns) { ['User.foo', 'User.bar', 'User.baz'] }
-
         expect(datatable.send(:sort_column, sort_view.params[:order]["0"])).to eq('users.bar')
       end
+      it 'returns correct column name from the #sorting_columns hash when multiple ordering is performed'  do
+        order_by_two_columns = params.merge(
+            :order => {
+                "0" => {
+                    :column => "1",
+                    :dir => "asc"
+                },
+                "1" => {
+                    :column => "0",
+                    :dir => "asc"
+                }
+            }
+
+        )
+        sort_view = double(
+            'view', :params => order_by_two_columns
+        )
+        datatable = AjaxDatatablesRails::Base.new(sort_view)
+        allow(datatable).to receive(:sortable_displayed_columns) { {"0"=>"0", "1"=> "1"} }
+        allow(datatable).to receive(:sortable_columns) { {"0"=>"User.foo", "1"=>"User.bar", "2"=>"User.baz"} }
+        expect(datatable.send(:sort_column, sort_view.params[:order]["1"])).to eq('users.foo')
+      end
+
     end
+
 
     describe '#sort_direction' do
       it 'matches value of params[:sSortDir_0]' do
@@ -202,7 +225,7 @@ describe AjaxDatatablesRails::Base do
 
     before(:each) do
       allow(datatable).to receive(:sortable_columns) { ['User.foo', 'User.bar'] }
-      allow(datatable).to receive(:sortable_displayed_columns) { ["0", "1"] }
+      allow(datatable).to receive(:sortable_displayed_columns) { {"0"=>"0", "1"=> "1"} }
     end
 
     describe '#paginate_records' do


### PR DESCRIPTION
sample code:

```
  def data
    records.map do |record|
      {
          first_name: record.first_name,
          last_name: record.last_name,
          bio: record.bio
      }
    end
  end
```

   def sortable_columns
     @sortable_columns ||= {
         first_name: 'User.first_name',
         last_name: 'User.last_name',
         bio: 'User.bio'
     }
  end

even if first_name is changed to the second column in the view, we dont have to change the ajax datatable configuration because it no longer depends on the the array index.,but on the hash_key
