### PR TITLE
Fix issue with columns where searchable is disabled on front end

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -139,6 +139,7 @@ module AjaxDatatablesRails
 
     def aggregate_query
       conditions = searchable_columns.each_with_index.map do |column, index|
+        index = searchable_displayed_column_indexes[index]
         value = params[:columns]["#{index}"][:search][:value] if params[:columns]
         search_condition(column, value) unless value.blank?
       end
@@ -173,11 +174,11 @@ module AjaxDatatablesRails
     end
 
     def deprecated_sort_column(item)
-      sortable_columns[sortable_displayed_columns.index(item[:column])]
+      sortable_columns[sortable_displayed_column_indexes.index(item[:column])]
     end
 
     def new_sort_column(item)
-      model, column = sortable_columns[sortable_displayed_columns.index(item[:column])].split('.')
+      model, column = sortable_columns[sortable_displayed_column_indexes.index(item[:column])].split('.')
       col = [model.constantize.table_name, column].join('.')
     end
 
@@ -186,16 +187,12 @@ module AjaxDatatablesRails
       options.include?(item[:dir]) ? item[:dir].upcase : 'ASC'
     end
 
-    def sortable_displayed_columns
-      @sortable_displayed_columns ||= generate_sortable_displayed_columns
+    def sortable_displayed_column_indexes
+      @sortable_displayed_column_indexes ||= params[:columns].map {|k, v| k if v[:orderable] == 'true' }.reject(&:nil?)
     end
 
-    def generate_sortable_displayed_columns
-      @sortable_displayed_columns = []
-      params[:columns].each_value do |column|
-        @sortable_displayed_columns << column[:data] if column[:orderable] == 'true'
-      end
-      @sortable_displayed_columns
+    def searchable_displayed_column_indexes
+      @searchable_displayed_column_indexes ||= params[:columns].map {|k, v| k if v[:searchable] == 'true' }.reject(&:nil?)
     end
 
     def load_paginator

--- a/spec/ajax-datatables-rails/ajax_datatables_rails_spec.rb
+++ b/spec/ajax-datatables-rails/ajax_datatables_rails_spec.rb
@@ -81,7 +81,7 @@ describe AjaxDatatablesRails::Base do
           'view', :params => params
         )
         datatable = AjaxDatatablesRails::Base.new(sort_view)
-        allow(datatable).to receive(:sortable_displayed_columns) { ["0", "1"] }
+        allow(datatable).to receive(:sortable_displayed_column_indexes) { ["0", "1"] }
         allow(datatable).to receive(:sortable_columns) { ['User.foo', 'User.bar', 'User.baz'] }
 
         expect(datatable.send(:sort_column, sort_view.params[:order]["0"])).to eq('users.bar')
@@ -202,7 +202,7 @@ describe AjaxDatatablesRails::Base do
 
     before(:each) do
       allow(datatable).to receive(:sortable_columns) { ['User.foo', 'User.bar'] }
-      allow(datatable).to receive(:sortable_displayed_columns) { ["0", "1"] }
+      allow(datatable).to receive(:sortable_displayed_column_indexes) { ["0", "1"] }
     end
 
     describe '#paginate_records' do
@@ -227,6 +227,7 @@ describe AjaxDatatablesRails::Base do
       it 'applies search like functionality on a collection' do
         datatable = AjaxDatatablesRails::Base.new(search_view)
         allow(datatable).to receive(:searchable_columns) { ['users.foo'] }
+        allow(datatable).to receive(:searchable_displayed_column_indexes) { ['0'] }
 
         expect(records).to receive(:where)
         records.where
@@ -241,6 +242,7 @@ describe AjaxDatatablesRails::Base do
       it 'applies search like functionality on a collection' do
         datatable = AjaxDatatablesRails::Base.new(search_view)
         allow(datatable).to receive(:searchable_columns) { ['user_datas.bar'] }
+        allow(datatable).to receive(:searchable_displayed_column_indexes) { ['0'] }
 
         expect(records).to receive(:where)
         records.where


### PR DESCRIPTION
This is very similar to the other pull request I did #74 

This branch adds the same functionality for searching on individual columns. It makes sure that the columns on the front-end are matched up with the correct `searchable_columns`. 

This branch also refactors the sloppy code I introduced in the first branch and renames the methods to more accurately represent what they are returning.  
