### PR TITLE
Integrated count in fetch query.

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -42,10 +42,11 @@ module AjaxDatatablesRails
     def as_json(options = {})
       filtered_data = data
       total_count = get_raw_records.count(:all)
+      filtered_count = (records.blank? ? 0 : records.first['filtered_count']) || total_count
       {
         :draw => params[:draw].to_i,
         :recordsTotal => total_count,
-        :recordsFiltered => records.first['filtered_count'] || total_count,
+        :recordsFiltered => filtered_count,
         :data => filtered_data
       }
     end

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -40,11 +40,13 @@ module AjaxDatatablesRails
     end
 
     def as_json(options = {})
+      filtered_data = data
+      total_count = get_raw_records.count(:all)
       {
         :draw => params[:draw].to_i,
-        :recordsTotal =>  get_raw_records.count(:all),
-        :recordsFiltered => filter_records(get_raw_records).count(:all),
-        :data => data
+        :recordsTotal => total_count,
+        :recordsFiltered => records.first['filtered_count'] || total_count,
+        :data => filtered_data
       }
     end
 
@@ -65,7 +67,7 @@ module AjaxDatatablesRails
     end
 
     def fetch_records
-      records = get_raw_records
+      records = get_raw_records.select('*, count(*) OVER() as filtered_count')
       records = sort_records(records) if params[:order].present?
       records = filter_records(records) if params[:search].present?
       records = paginate_records(records) unless params[:length].present? && params[:length] == '-1'


### PR DESCRIPTION
This results in only one execution of the expensive search query (with
possibly multiple ILIKES), making an ajax request about twice as fast. 

This works for postgresql > 8.4, see also http://stackoverflow.com/questions/156114/best-way-to-get-result-count-before-limit-was-applied-in-php-postgresql
