### PR TITLE
Rails 5 Compatibility

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -74,7 +74,7 @@ module AjaxDatatablesRails
 
     def sort_records(records)
       sort_by = []
-      params[:order].each_value do |item|
+      params[:order].each do |_, item|
         sort_by << "#{sort_column(item)} #{sort_direction(item)}"
       end
       records.order(sort_by.join(", "))
@@ -194,7 +194,7 @@ module AjaxDatatablesRails
 
     def generate_sortable_displayed_columns
       @sortable_displayed_columns = []
-      params[:columns].each_value do |column|
+      params[:columns].each do |_, column|
         @sortable_displayed_columns << column[:data] if column[:orderable] == 'true'
       end
       @sortable_displayed_columns


### PR DESCRIPTION
I was running into the following error when upgrading an app to the Rails 5 beta 1:

```
NoMethodError - undefined method `each_value' for {"0"=>{"column"=>"0", "dir"=>"asc"}}:ActionController::Parameters:
  ajax-datatables-rails (0.3.1) lib/ajax-datatables-rails/base.rb:76:in `sort_records'
  ajax-datatables-rails (0.3.1) lib/ajax-datatables-rails/base.rb:68:in `fetch_records'
  ajax-datatables-rails (0.3.1) lib/ajax-datatables-rails/base.rb:63:in `records'
```

I was able to resolve it by changing the `each_value` methods to `each`. Not sure if this is the preferred fix, but it worked for me.
