### PR TITLE
Adds 'no_split_term' config option. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,13 @@ AjaxDatatablesRails.configure do |config|
 
   # available options for paginator are: :simple_paginator, :kaminari, :will_paginate
   # config.paginator = :simple_paginator
+
+  # avabilable options for no_split_terms are: true, false
+  #
+  # By default, search terms "hello world" will search for records matching "hello"
+  # OR "world". When set to true, it will search for records matching the entire
+  # string.
+  # config.no_split_terms = false
 end
 ```
 
@@ -522,6 +529,10 @@ Uncomment the `config.paginator` line to set `kaminari or will_paginate` if
 included in your project. It defaults to `simple_paginator`, it falls back to
 passing `offset` and `limit` at the database level (through `ActiveRecord`
 of course).
+
+Uncomment the `config.no_split_terms` line and set to true if you want
+to search based on the the whole search string in it's entirety, rather
+than each individual word.
 
 If you want to make the file from scratch, just copy the above code block into
 a file inside the `config/initializers` directory.

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -107,7 +107,9 @@ module AjaxDatatablesRails
     end
 
     def build_conditions_for(query)
-      search_for = query.split(' ')
+      search_for = query.split(' ') unless config.no_split_terms
+      search_for = [query] if config.no_split_terms
+
       criteria = search_for.inject([]) do |criteria, atom|
         criteria << searchable_columns.map { |col| search_condition(col, atom) }.reduce(:or)
       end.reduce(:and)
@@ -148,7 +150,7 @@ module AjaxDatatablesRails
 
     def typecast
       case config.db_adapter
-      when :oracle then 'VARCHAR2(4000)'  
+      when :oracle then 'VARCHAR2(4000)'
       when :pg then 'VARCHAR'
       when :mysql2 then 'CHAR'
       when :sqlite3 then 'TEXT'

--- a/lib/ajax-datatables-rails/config.rb
+++ b/lib/ajax-datatables-rails/config.rb
@@ -21,5 +21,6 @@ module AjaxDatatablesRails
     # default db_adapter is pg (postgresql)
     config_accessor(:db_adapter) { :pg }
     config_accessor(:paginator) { :simple_paginator }
+    config_accessor(:no_split_terms) { false }
   end
 end

--- a/lib/generators/datatable/templates/ajax_datatables_rails_config.rb
+++ b/lib/generators/datatable/templates/ajax_datatables_rails_config.rb
@@ -4,4 +4,11 @@ AjaxDatatablesRails.configure do |config|
 
   # available options for paginator are: :simple_paginator, :kaminari, :will_paginate
   # config.paginator = :simple_paginator
+
+  # avabilable options for no_split_terms are: true, false
+  #
+  # By default, search terms "hello world" will search for records matching "hello"
+  # OR "world". When set to true, it will search for records matching the entire
+  # string.
+  # config.no_split_terms = false
 end

--- a/spec/ajax-datatables-rails/ajax_datatables_rails_spec.rb
+++ b/spec/ajax-datatables-rails/ajax_datatables_rails_spec.rb
@@ -280,12 +280,21 @@ describe AjaxDatatablesRails::Configuration do
     it "default db_adapter should :pg (postgresql)" do
       expect(config.db_adapter).to eq(:pg)
     end
+
+    it 'default no_split_terms should be false' do
+      expect(config.no_split_terms).to eq(false)
+    end
   end
 
   describe "custom config" do
     it 'should accept db_adapter custom value' do
       config.db_adapter = :mysql2
       expect(config.db_adapter).to eq(:mysql2)
+    end
+
+    it 'should accept no_split_terms custom value' do
+      config.no_split_terms = true
+      expect(config.no_split_terms).to eq(true)
     end
   end
 


### PR DESCRIPTION
When set to true, the search term is not split into individual words, rather the whole string is searched for in the targeted columns. 
