### PR TITLE
recordsTotal and recordsFiltered can be hash object when running aggregate query

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -40,10 +40,12 @@ module AjaxDatatablesRails
     end
 
     def as_json(options = {})
+      records_total = get_raw_records.count(:all)
+      records_filtered = filter_records(get_raw_records).count(:all)
       {
         :draw => params[:draw].to_i,
-        :recordsTotal =>  get_raw_records.count(:all),
-        :recordsFiltered => filter_records(get_raw_records).count(:all),
+        :recordsTotal => records_total.is_a?(Hash) ? records_total.size : records_total,
+        :recordsFiltered => records_filtered.is_a?(Hash) ? records_filtered.size : records_filtered,
         :data => data
       }
     end


### PR DESCRIPTION
Thanks for your work, antillas21! ajax-datatables-rails gem is very helpful that saves me a lot of development time.

Recently I am on a project which includes a datatable, whose columns come from 2 models, with one to many relationship, say 1 user has many posts. And one column in the datatable shows the count of posts of each user.
Since this posts count column need to be sorted, a virtual attribute is not enough, so I write a aggregate query in get_raw_records, like:

`User.select("count(posts.id) as posts_count, users.*").joins("left outer join posts on posts.user_id = users.id").group("users.id")`  

then I added posts_count into @sortable_columns, the sorting works well, except the recordsTotal and recordsFiltered in response json are hash object instead of a number, it looks like:

> {"1" => 5, "2" => 1, "3" => 2} 

in which the key is the user id, while the value is the posts count of each user.

In this case,  we need the size of hash to be recordsTotal and recordsFiltered which reflect the count of user, not the hash object.

Looking forward your response and opinion, thanks!
