### PR TITLE
Rename `additional_datas` method as `additional_data`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,12 +353,12 @@ end
 ```
 
 
-#### Additional datas
+#### Additional data
 
-You can inject other key/value pairs in the rendered JSON by defining the `#additional_datas` method :
+You can inject other key/value pairs in the rendered JSON by defining the `#additional_data` method :
 
 ```ruby
-def additional_datas
+def additional_data
   {
     foo: 'bar'
   }

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -33,7 +33,7 @@ module AjaxDatatablesRails
       fail(NotImplementedError, data_error_text)
     end
 
-    def additional_datas
+    def additional_data
       {}
     end
 
@@ -42,7 +42,7 @@ module AjaxDatatablesRails
         recordsTotal: records_total_count,
         recordsFiltered: records_filtered_count,
         data: sanitize(data)
-      }.merge(additional_datas)
+      }.merge(get_additional_data)
     end
 
     def records
@@ -71,6 +71,23 @@ module AjaxDatatablesRails
     end
 
     private
+
+    # This method is necessary for smooth transition from
+    # `additinonal_datas` method to `additional_data`
+    # without breaking change.
+    def get_additional_data
+      if respond_to?(:additional_datas)
+        puts <<-eos
+          `additional_datas` has been deprecated and
+          will be removed in next major version update!
+          Please use `additional_data` instead.
+        eos
+
+        additional_datas
+      else
+        additional_data
+      end
+    end
 
     def sanitize(data)
       data.map do |record|

--- a/spec/ajax-datatables-rails/base_spec.rb
+++ b/spec/ajax-datatables-rails/base_spec.rb
@@ -98,10 +98,10 @@ describe AjaxDatatablesRails::Base do
         expect(data[:data].size).to eq 5
       end
 
-      context 'with additional_datas' do
+      context 'with additional_data' do
         it 'should return a hash' do
           create_list(:user, 5)
-          expect(datatable).to receive(:additional_datas){ { foo: 'bar' } }
+          expect(datatable).to receive(:additional_data){ { foo: 'bar' } }
           data = datatable.as_json
           expect(data[:recordsTotal]).to eq 5
           expect(data[:recordsFiltered]).to eq 5


### PR DESCRIPTION
Data is already plural and singular form of it is +datum+
therefore naming a method as `additional_datas` is wrong.
This commit renames the method without breaking change but
with deprecating the old one.