### PR TITLE
Fix erroneous offset/start behavior

### DIFF
--- a/lib/ajax-datatables-rails/datatable/datatable.rb
+++ b/lib/ajax-datatables-rails/datatable/datatable.rb
@@ -56,7 +56,7 @@ module AjaxDatatablesRails
       end
 
       def offset
-        (page - 1) * per_page
+        options.fetch(:start, 0).to_i
       end
 
       def page

--- a/spec/ajax-datatables-rails/base_spec.rb
+++ b/spec/ajax-datatables-rails/base_spec.rb
@@ -155,10 +155,10 @@ describe AjaxDatatablesRails::Base do
           expect(datatable.datatable.send(:offset)).to eq(0)
         end
 
-        it 'matches the value on view params[:start] minus 1' do
+        it 'matches the value on view params[:start]' do
           paginated_view = double('view', params: { start: '11' })
           datatable = described_class.new(paginated_view)
-          expect(datatable.datatable.send(:offset)).to eq(10)
+          expect(datatable.datatable.send(:offset)).to eq(11)
         end
       end
 

--- a/spec/ajax-datatables-rails/datatable/datatable_spec.rb
+++ b/spec/ajax-datatables-rails/datatable/datatable_spec.rb
@@ -73,7 +73,7 @@ describe AjaxDatatablesRails::Datatable::Datatable do
     end
 
     it 'offset' do
-      expect(datatable.offset).to eq(45)
+      expect(datatable.offset).to eq(50)
     end
 
     it 'page' do

--- a/spec/ajax-datatables-rails/orm/active_record_paginate_records_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_paginate_records_spec.rb
@@ -38,16 +38,16 @@ describe AjaxDatatablesRails::ORM::ActiveRecord do
       if AjaxDatatablesRails.config.db_adapter.in? %i[oracle oracleenhanced]
         if Rails.version.in? %w[4.0.13 4.1.15 4.2.9]
           expect(datatable.paginate_records(records).to_sql).to include(
-            'rownum <= 50'
+            'rownum <= 51'
           )
         else
           expect(datatable.paginate_records(records).to_sql).to include(
-            'rownum <= (25 + 25)'
+            'rownum <= (26 + 25)'
           )
         end
       else
         expect(datatable.paginate_records(records).to_sql).to include(
-          'LIMIT 25 OFFSET 25'
+          'LIMIT 25 OFFSET 26'
         )
       end
     end


### PR DESCRIPTION
This changes ajax-datatables-rails to use the passed in `start` parameter for the SQL `OFFSET` value, rather than basing the offset on the calculated page number. I think this is the correct behavior, and mirrors what DataTable's own [server side example does](https://github.com/DataTables/DataTables/blob/1.10.16/examples/server_side/scripts/ssp.class.php#L97).

If the start value wasn't an exact multiple of the limit, then previously the database query would not acknowledge intermediate offset values. So, for example, if a request with `start=20&limit=100` was made, ajax-datatables-rails would perform a `LIMIT 100 OFFSET 0` query, instead of `LIMIT 100 OFFSET 20` (which is what is believe should happen).

I suspect you wouldn't see this issue if you were using explicit page-based pagination where `start` was always a multiple of `limit`. However, if you're using DataTables with infinite scrolling pagination, then the start value might be fairly random. With the previous behavior, infinite scrolling would appear to do strange things, since new requests like `start=20&limit=100` and `start=55&limit=100` might be made, but the responses would continue to contain the same identical 1-100 results.

I think I've adjusted the Oracle tests appropriately, but since these don't seem to be passing on Travis CI currently, I'm not entirely sure. But the other databases all seem to be passing.