### PR TITLE
Enable support for Uppercase Column Names

### DIFF
--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -77,6 +77,7 @@ module AjaxDatatablesRails
       end
 
       def field
+        binding.pry
         source.split('.').last.delete("\"","").to_sym
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -52,6 +52,7 @@ module AjaxDatatablesRails
 
       # Add sort_field option to allow overriding of sort field
       def sort_field
+        binding.pry
         @view_column[:sort_field] || field
       end
 
@@ -85,6 +86,7 @@ module AjaxDatatablesRails
       end
 
       def sort_query
+        binding.pry
         custom_field? ? source : "#{table.name}.#{sort_field}"
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -52,6 +52,7 @@ module AjaxDatatablesRails
 
       # Add sort_field option to allow overriding of sort field
       def sort_field
+        binding.pry
         @view_column[:sort_field] || field
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -128,7 +128,6 @@ module AjaxDatatablesRails
         when :end_with
           casted_column.matches("%#{formated_value}")
         when :like
-          binding.pry
           casted_column.matches("%#{formated_value}%")
         else
           nil

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -145,6 +145,7 @@ module AjaxDatatablesRails
       end
 
       def casted_column
+        binding.pry
         ::Arel::Nodes::NamedFunction.new('CAST', [table[field].as(typecast)])
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -77,7 +77,7 @@ module AjaxDatatablesRails
       end
 
       def field
-        source.split('.').last.to_sym
+        source.split('.').last.gsub("\"","").to_sym
       end
 
       def search_query
@@ -145,6 +145,7 @@ module AjaxDatatablesRails
       end
 
       def casted_column
+        binding.pry
         ::Arel::Nodes::NamedFunction.new('CAST', [table[field].as(typecast)])
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -145,7 +145,6 @@ module AjaxDatatablesRails
       end
 
       def casted_column
-        binding.pry
         ::Arel::Nodes::NamedFunction.new('CAST', [table[field].as(typecast)])
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -52,7 +52,6 @@ module AjaxDatatablesRails
 
       # Add sort_field option to allow overriding of sort field
       def sort_field
-        binding.pry
         @view_column[:sort_field] || field
       end
 
@@ -86,10 +85,15 @@ module AjaxDatatablesRails
       end
 
       def sort_query
-        binding.pry
-        custom_field? ? source : "#{table.name}.#{sort_field}"
+        sort_field_as_string=stringify_case_sensitive_symbol(sort_field)
+        custom_field? ? source : "#{table.name}.#{sort_field_as_string}"
       end
-
+      
+      def stringify_case_sensitive_symbol(symbol)
+       /[[:upper:]]/.match(symbol.to_s) ? "\""+symbol.to_s+"\"" : symbol.to_s
+      end
+      
+      
       def formated_value
         formater ? formater.call(search.value) : search.value
       end
@@ -147,7 +151,6 @@ module AjaxDatatablesRails
       end
 
       def casted_column
-        binding.pry
         ::Arel::Nodes::NamedFunction.new('CAST', [table[field].as(typecast)])
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -128,6 +128,7 @@ module AjaxDatatablesRails
         when :end_with
           casted_column.matches("%#{formated_value}")
         when :like
+          binding.pry
           casted_column.matches("%#{formated_value}%")
         else
           nil

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -77,7 +77,6 @@ module AjaxDatatablesRails
       end
 
       def field
-        binding.pry
         source.split('.').last.delete("\"").to_sym
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -78,7 +78,7 @@ module AjaxDatatablesRails
 
       def field
         binding.pry
-        source.split('.').last.delete("\"","").to_sym
+        source.split('.').last.delete("\"").to_sym
       end
 
       def search_query

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -77,7 +77,7 @@ module AjaxDatatablesRails
       end
 
       def field
-        source.split('.').last.gsub("\"","").to_sym
+        source.split('.').last.delete("\"","").to_sym
       end
 
       def search_query

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -52,7 +52,6 @@ module AjaxDatatablesRails
 
       # Add sort_field option to allow overriding of sort field
       def sort_field
-        binding.pry
         @view_column[:sort_field] || field
       end
 

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -146,6 +146,7 @@ module AjaxDatatablesRails
       end
 
       def casted_column
+        binding.pry
         ::Arel::Nodes::NamedFunction.new('CAST', [table[field].as(typecast)])
       end
 

--- a/lib/ajax-datatables-rails/orm/active_record.rb
+++ b/lib/ajax-datatables-rails/orm/active_record.rb
@@ -7,7 +7,6 @@ module AjaxDatatablesRails
       end
 
       def filter_records(records)
-        binding.pry
         records.where(build_conditions)
       end
 

--- a/lib/ajax-datatables-rails/orm/active_record.rb
+++ b/lib/ajax-datatables-rails/orm/active_record.rb
@@ -7,6 +7,7 @@ module AjaxDatatablesRails
       end
 
       def filter_records(records)
+        binding.pry
         records.where(build_conditions)
       end
 


### PR DESCRIPTION
Added #stringify_case_sensitive_symbol  method to properly convert symbols to column names for use in sql queries, taking into account the case of the letters, so that symbols containing upper case letters are surrounded with quotes.

modified #field methods to prevent quotes from being included in the symbol

modified #sort_query to use properly stringified symbol

Im somewhat of a beginner contributor so please let me know if there are ways to improve my contributions 