### PR TITLE
Fixes errors when options[param] is nil

### DIFF
--- a/lib/ajax-datatables-rails/datatable/datatable.rb
+++ b/lib/ajax-datatables-rails/datatable/datatable.rb
@@ -68,6 +68,7 @@ module AjaxDatatablesRails
       end
 
       def get_param(param)
+        return {} if options[param].nil?
         options[param].to_unsafe_h.with_indifferent_access
       end
 


### PR DESCRIPTION
I got errors when running tests like: NoMethodError: undefined method `to_unsafe_h'. This fixes it.