### PR TITLE
sanitize(data) disabiguation

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -33,7 +33,7 @@ module AjaxDatatablesRails
       {
         recordsTotal:    records_total_count,
         recordsFiltered: records_filtered_count,
-        data:            AjaxDatatablesRails::Base.instance_method(:sanitize).bind(self).call(data),
+        data:            sanitize_data(data),
       }.merge(get_additional_data)
     end
 
@@ -81,7 +81,7 @@ module AjaxDatatablesRails
       end
     end
 
-    def sanitize(data)
+    def sanitize_data(data)
       data.map do |record|
         if record.is_a?(Array)
           record.map { |td| ERB::Util.html_escape(td) }

--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -33,7 +33,7 @@ module AjaxDatatablesRails
       {
         recordsTotal:    records_total_count,
         recordsFiltered: records_filtered_count,
-        data:            sanitize(data),
+        data:            AjaxDatatablesRails::Base.instance_method(:sanitize).bind(self).call(data),
       }.merge(get_additional_data)
     end
 

--- a/lib/ajax-datatables-rails/version.rb
+++ b/lib/ajax-datatables-rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AjaxDatatablesRails
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
sanitize is such an overused method name that it binds to a lot of different things. Because datatables inherit from AjaxDatatablesRails::ActiveRecord which inherits from AjaxDatatablesRails::Base for some odd reason sanitize binds to ActionView's sanitize method which eventually gets to Loofah and Nokogiri which doesn't handle arrays and throws the error I reported in https://github.com/jbox-web/ajax-datatables-rails/issues/325 surprisingly even when you call self.sanitize it does not call the method in the same namespace and file!! because technically the sanitize function that we want is AjaxDatatablesRails::Base's function, to disabiguate we could either rename the function (and because I don't know what else calls it that seemed like a bad idea), or we could help disambiguate by being explicit about which super's method to call.  The only way I saw to do this is to call it like this: 
```ruby
AjaxDatatablesRails::Base.instance_method(:sanitize).bind(self).call(data).
```
That may make for unreadable code to some, we could always define another method that then calls the above.  Or if you have another way to fix, have at it.  But this breaks in Ruby 2.4.0 and rails 5.2.3 for me without this change.