### PR TITLE
Greater than the current date support

### DIFF
--- a/lib/ajax-datatables-rails/datatable/column/date_filter.rb
+++ b/lib/ajax-datatables-rails/datatable/column/date_filter.rb
@@ -55,7 +55,7 @@ module AjaxDatatablesRails
         end
 
         def range_end_casted
-          range_end.blank? ? Time.current : parse_date("#{range_end} 23:59:59")
+          range_end.blank? ? parse_date("9999-12-31 23:59:59") : parse_date("#{range_end} 23:59:59")
         end
 
         def parse_date(date)


### PR DESCRIPTION
Hello,
thank you for a great gem :)

I just noticed that date_range doesn't support searching by a date greater than today. If you want to select jobs planned from tomorrow without end date it returns nothing.

I improved range_end_casted method to support this case.

Greetings :)