### PR TITLE
Add imports-loader options object

### DIFF
--- a/doc/webpack.md
+++ b/doc/webpack.md
@@ -24,7 +24,10 @@ In `config/webpack/loaders/datatables.js` :
 ```js
 module.exports = {
   test: /datatables\.net.*/,
-  loader: 'imports-loader?define=>false'
+  loader: 'imports-loader',
+  options: {
+    additionalCode: 'var define = false;'
+  }
 }
 ```
 


### PR DESCRIPTION
imports-loader v1.1.0 changes [syntax](https://github.com/webpack-contrib/imports-loader/blob/f71a9fbb3ade447ae9cf57044814d0ca693fc96a/README.md#disable-amd-import-syntax) for disabling AMD import.