### PR TITLE
Fix Rare case error uninitialized constant AjaxDatatablesRails::ActiveRecord::Base

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -3,7 +3,7 @@
 module AjaxDatatablesRails
   class Base
 
-    class_attribute :db_adapter, default: ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+    class_attribute :db_adapter, default: ::ActiveRecord::Base.connection.adapter_name.downcase.to_sym
     class_attribute :nulls_last, default: false
 
     attr_reader :params, :options, :datatable


### PR DESCRIPTION
It's not happen in every rails app, but one of my app in Rails 6.1 do have below error and after using Global `::ActiveRecord::Base.connection.`, seems fix it.

```log
[sccsa_web@brave-cat-3 current]$ /home/sccsa_web/.rbenv/bin/rbenv exec bundle exec puma -C /var/www/sccsa_web/shared/puma.rb
Puma starting in single mode...
* Puma version: 5.1.1 (ruby 3.0.0-p0) ("At Your Service")
*  Min threads: 0
*  Max threads: 16
*  Environment: staging
*          PID: 19336
! Unable to load application: NameError: uninitialized constant AjaxDatatablesRails::ActiveRecord::Base
Did you mean?  AjaxDatatablesRails::Base
bundler: failed to load command: puma (/var/www/sccsa_web/shared/bundle/ruby/3.0.0/bin/puma)
/var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/ajax-datatables-rails-1.3.0/lib/ajax-datatables-rails/base.rb:6:in `<class:Base>': uninitialized constant AjaxDatatablesRails::ActiveRecord::Base (NameError)
Did you mean?  AjaxDatatablesRails::Base
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/ajax-datatables-rails-1.3.0/lib/ajax-datatables-rails/base.rb:4:in `<module:AjaxDatatablesRails>'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/ajax-datatables-rails-1.3.0/lib/ajax-datatables-rails/base.rb:3:in `<main>'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:26:in `require'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:409:in `const_get'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:409:in `block (2 levels) in eager_load'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:733:in `block in ls'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:725:in `foreach'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:725:in `ls'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:404:in `block in eager_load'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:393:in `synchronize'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:393:in `eager_load'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:508:in `each'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader.rb:508:in `eager_load_all'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/railties-6.1.0/lib/rails/application/finisher.rb:133:in `block in <module:Finisher>'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/railties-6.1.0/lib/rails/initializable.rb:32:in `instance_exec'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/railties-6.1.0/lib/rails/initializable.rb:32:in `run'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/railties-6.1.0/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:347:in `each'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:347:in `call'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/railties-6.1.0/lib/rails/initializable.rb:60:in `run_initializers'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/railties-6.1.0/lib/rails/application.rb:384:in `initialize!'
	from /var/www/sccsa_web/current/config/environment.rb:7:in `<top (required)>'
	from /var/www/sccsa_web/current/config.ru:5:in `require_relative'
	from /var/www/sccsa_web/current/config.ru:5:in `block in <main>'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `eval'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `new_from_string'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/builder.rb:105:in `load_file'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/builder.rb:66:in `parse_file'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/lib/puma/configuration.rb:342:in `load_rackup'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/lib/puma/configuration.rb:264:in `app'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/lib/puma/runner.rb:138:in `load_and_bind'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/lib/puma/single.rb:44:in `run'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/lib/puma/launcher.rb:182:in `run'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/lib/puma/cli.rb:80:in `run'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/gems/puma-5.1.1/bin/puma:10:in `<top (required)>'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/bin/puma:23:in `load'
	from /var/www/sccsa_web/shared/bundle/ruby/3.0.0/bin/puma:23:in `<top (required)>'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:494:in `exec'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:24:in `start'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bundler-2.2.4/exe/bundle:49:in `block in <top (required)>'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	from /home/sccsa_web/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bundler-2.2.4/exe/bundle:37:in `<top (required)>'
	from /home/sccsa_web/.rbenv/versions/3.0.0/bin/bundle:23:in `load'
	from /home/sccsa_web/.rbenv/versions/3.0.0/bin/bundle:23:in `<main>'
```