### PR TITLE
Allow to set a table alias on columns

### DIFF
--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -32,7 +32,15 @@ module AjaxDatatablesRails
       end
 
       def table
-        model.respond_to?(:arel_table) ? model.arel_table : model
+        if model.respond_to?(:arel_table)
+          table_alias.present? ? model.arel_table.alias(table_alias) : model.arel_table
+        else
+          model
+        end
+      end
+
+      def table_alias
+        @table_alias ||= @view_column[:table_alias]
       end
 
       def model

--- a/spec/ajax-datatables-rails/datatable/column_spec.rb
+++ b/spec/ajax-datatables-rails/datatable/column_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe AjaxDatatablesRails::Datatable::Column do
       end
     end
 
+    describe '#table_alias' do
+      it 'returns nil as the table_alias' do
+        expect(column.table_alias).to eq nil
+      end
+    end
+
     describe '#table' do
       context 'with ActiveRecord ORM' do
         it 'returns the corresponding AR table' do
@@ -217,6 +223,24 @@ RSpec.describe AjaxDatatablesRails::Datatable::Column do
 
     it 'raises error' do
       expect { datatable.to_json }.to raise_error(AjaxDatatablesRails::Error::InvalidSearchColumn).with_message("Check that column 'foo' exists in view_columns")
+    end
+  end
+
+  describe 'table name overwrites for named joins' do
+    let(:datatable) { NamedJoinDatatable.new(group_sample_params) }
+
+    let(:column) { datatable.datatable.columns.last }
+
+    describe '#source' do
+      it 'returns the data source from view_column' do
+        expect(column.source).to eq 'User.username'
+      end
+    end
+
+    describe '#table_alias' do
+      it 'returns the data source from table_alias' do
+        expect(column.table_alias).to eq 'admin'
+      end
     end
   end
 end

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :group do |f|
+    f.name   { Faker::Team.name }
+    f.admin  { build(:user) }
+  end
+end

--- a/spec/support/datatables/named_join_datatable.rb
+++ b/spec/support/datatables/named_join_datatable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class NamedJoinDatatable < AjaxDatatablesRails::ActiveRecord
+  def view_columns
+    @view_columns ||= {
+      username:   { source: 'User.username' },
+      group_name: { source: 'Group.name' },
+      group_admin: { source: 'User.username', table_alias: 'admin' }
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        username:   record.username,
+        group_name: record.group&.name,
+        group_admin: record.group&.admin&.username,
+      }
+    end
+  end
+
+  def get_raw_records
+    User.left_outer_joins(group: :admin)
+        .where(admin: { id: [nil, 1..] }) # Hack to force alias in Rails
+  end
+end

--- a/spec/support/helpers/params.rb
+++ b/spec/support/helpers/params.rb
@@ -60,6 +60,41 @@ def sample_params
   )
 end
 
+def group_sample_params
+  ActionController::Parameters.new(
+    {
+      'draw' => '1',
+      'columns' => {
+        '0' => {
+          'data' => 'username', 'name' => '', 'searchable' => 'true', 'orderable' => 'true',
+          'search' => {
+            'value' => '', 'regex' => 'false'
+          }
+        },
+        '1' => {
+          'data' => 'group_name', 'name' => '', 'searchable' => 'true', 'orderable' => 'true',
+          'search' => {
+            'value' => '', 'regex' => 'false'
+          }
+        },
+        '2' => {
+          'data' => 'group_admin', 'name' => '', 'searchable' => 'true', 'orderable' => 'false',
+          'search' => {
+            'value' => '', 'regex' => 'false'
+          }
+        }
+      },
+      'order' => {
+        '0' => { 'column' => '0', 'dir' => 'asc' },
+      },
+      'start' => '0', 'length' => '10', 'search' => {
+        'value' => '', 'regex' => 'false'
+      },
+      '_' => '1423364387185'
+    }
+  )
+end
+
 def sample_params_json
   hash_params = sample_params.to_unsafe_h
   hash_params['columns'] = hash_params['columns'].values

--- a/spec/support/models/group.rb
+++ b/spec/support/models/group.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Group < ActiveRecord::Base
+  belongs_to :admin, class_name: 'User'
+  has_many :users
+end

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class User < ActiveRecord::Base
+  belongs_to :group, optional: true
+  has_many :admin_groups, foreign_key: :admin_id
+
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -9,6 +9,14 @@ ActiveRecord::Schema.define do
     t.string  :first_name
     t.string  :last_name
     t.integer :post_id
+    t.integer :group_id
+
+    t.timestamps null: false
+  end
+
+  create_table :groups, force: true do |t|
+    t.string  :name
+    t.integer :admin_id
 
     t.timestamps null: false
   end


### PR DESCRIPTION
I have to work with quite some big tables where we use information from various models. Often joining multiple information from the same table, but through a different association.

For example:
```
Group to have multiple Users
Group to belong to one User as an admin
```
And then showing a table like this:
```
User | Group name | Group admin
```
  
Inspired by the addition of Rails 6.1.1 to [allow where clause reference association by alias name](https://blog.saeloun.com/2021/01/25/rails-6-allow-where-clause-reference-association-by-alias-name.html) this PR tries to solve this issue by allowing to overwrite the `table_alias` of a particular column definition.

This solution should also solve the issue mentioned in https://github.com/jbox-web/ajax-datatables-rails/issues/363