### PR TITLE
Do not escape records hash values to allow using DT_RowAttr

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -98,7 +98,7 @@ module AjaxDatatablesRails
         if record.is_a?(Array)
           record.map { |td| ERB::Util.html_escape(td) }
         else
-          record.update(record) { |_, v| ERB::Util.html_escape(v) }
+          record.update(record) { |_, v| v.is_a?(Hash) ? v : ERB::Util.html_escape(v) }
         end
       end
     end


### PR DESCRIPTION
I might have overlooked something, but can't we skip escaping records hash values, so we could use for example `DT_RowAttr`?
I tested it locally and it all works just fine