### PR TITLE
fix: prevent establishing ActiveRecord connection on startup

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -3,7 +3,7 @@
 module AjaxDatatablesRails
   class Base
 
-    class_attribute :db_adapter, default: ::ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+    class_attribute :db_adapter, default: ::ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first.adapter.downcase.to_sym
     class_attribute :nulls_last, default: false
 
     attr_reader :params, :options, :datatable


### PR DESCRIPTION
Instead of creating a connection and looking at its database adapter, look at the configured adapter instead.

This prevents issues when trying to compile assets or running other rake tasks in `RAILS_ENV=production` that are supposed to work without a running database.