### PR TITLE
fix: prevent establishing ActiveRecord connection on startup without breaking tests

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -3,8 +3,14 @@
 module AjaxDatatablesRails
   class Base
 
-    class_attribute :db_adapter, default: ::ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+    class_attribute :db_adapter
     class_attribute :nulls_last, default: false
+
+    class << self
+      def db_adapter
+        self.db_adapter = ::ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+      end
+    end
 
     attr_reader :params, :options, :datatable
 


### PR DESCRIPTION
This PR solves the same issue as #406 but it keeps the current definition of default value. This ensures that the tests are still able to pass.

This is issue can be really annoying since it breaks the building of docker production images when compiling assets : no database can be accessible at this point.