### PR TITLE
Add support for postgis adapter

### DIFF
--- a/appraisal.yml
+++ b/appraisal.yml
@@ -12,6 +12,9 @@
   ruby-oci8:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'
+  activerecord-postgis-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "postgis" }'
 
 6.1.7:
   sqlite3:
@@ -26,6 +29,9 @@
   ruby-oci8:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'
+  activerecord-postgis-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "postgis" }'
 
 7.0.4:
   sqlite3:
@@ -40,3 +46,6 @@
   ruby-oci8:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'
+  activerecord-postgis-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "postgis" }'

--- a/gemfiles/rails_6.0.6.gemfile
+++ b/gemfiles/rails_6.0.6.gemfile
@@ -18,4 +18,8 @@ install_if -> { ENV["DB_ADAPTER"] == "oracle_enhanced" } do
   gem "ruby-oci8"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "postgis" } do
+  gem "activerecord-postgis-adapter"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_6.1.7.gemfile
+++ b/gemfiles/rails_6.1.7.gemfile
@@ -18,4 +18,8 @@ install_if -> { ENV["DB_ADAPTER"] == "oracle_enhanced" } do
   gem "ruby-oci8"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "postgis" } do
+  gem "activerecord-postgis-adapter"
+end
+
 gemspec path: "../"

--- a/gemfiles/rails_7.0.4.gemfile
+++ b/gemfiles/rails_7.0.4.gemfile
@@ -18,4 +18,8 @@ install_if -> { ENV["DB_ADAPTER"] == "oracle_enhanced" } do
   gem "ruby-oci8"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "postgis" } do
+  gem "activerecord-postgis-adapter"
+end
+
 gemspec path: "../"

--- a/lib/ajax-datatables-rails/datatable/simple_order.rb
+++ b/lib/ajax-datatables-rails/datatable/simple_order.rb
@@ -45,7 +45,7 @@ module AjaxDatatablesRails
         return unless sort_nulls_last?
 
         case @adapter
-        when :pg, :postgresql, :postgres, :oracle
+        when :pg, :postgresql, :postgres, :oracle, :postgis
           'NULLS LAST'
         when :mysql, :mysql2, :sqlite, :sqlite3
           'IS NULL'

--- a/spec/ajax-datatables-rails/datatable/column_spec.rb
+++ b/spec/ajax-datatables-rails/datatable/column_spec.rb
@@ -168,6 +168,11 @@ RSpec.describe AjaxDatatablesRails::Datatable::Column do
       expect(column.send(:type_cast)).to eq('VARCHAR')
     end
 
+    it 'returns VARCHAR if :db_adapter is :postgis' do
+      expect(datatable).to receive(:db_adapter) { :postgis }
+      expect(column.send(:type_cast)).to eq('VARCHAR')
+    end
+
     it 'returns VARCHAR2(4000) if :db_adapter is :oracle' do
       expect(datatable).to receive(:db_adapter) { :oracle }
       expect(column.send(:type_cast)).to eq('VARCHAR2(4000)')

--- a/spec/ajax-datatables-rails/datatable/simple_order_spec.rb
+++ b/spec/ajax-datatables-rails/datatable/simple_order_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe AjaxDatatablesRails::Datatable::SimpleOrder do
         end
       end
 
+      context 'with postgis database adapter' do
+        before { parent.db_adapter = :postgis }
+
+        it 'sql query' do
+          expect(nulls_last_order.query('email')).to eq('email DESC NULLS LAST')
+        end
+      end
+
       context 'with sqlite database adapter' do
         before { parent.db_adapter = :sqlite }
 

--- a/spec/support/helpers/params.rb
+++ b/spec/support/helpers/params.rb
@@ -70,7 +70,7 @@ end
 
 def nulls_last_sql(datatable)
   case datatable.db_adapter
-  when :pg, :postgresql, :postgres, :oracle
+  when :pg, :postgresql, :postgres, :oracle, :postgis
     'NULLS LAST'
   when :mysql, :mysql2, :sqlite, :sqlite3
     'IS NULL'


### PR DESCRIPTION
When trying to use the `nulls_last` option on a column, I started getting a runtime error stating that the database adapter was not supported. Upon digging further, the gem was supporting various postgres adapters but wasn't taking into account the postgis adapter.