### PR TITLE
Fix server-side out of order ajax responses

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -73,11 +73,13 @@ module AjaxDatatablesRails
 
     # JSON structure sent to jQuery DataTables
     def as_json(*)
+      draw_resp = (params[:draw].present?) ? { draw: params[:draw].to_i } : { }
+
       {
         recordsTotal:    records_total_count,
         recordsFiltered: records_filtered_count,
         data:            sanitize_data(data),
-      }.merge(additional_data)
+      }.merge(draw_resp).merge(additional_data)
     end
 
     # User helper methods

--- a/spec/ajax-datatables-rails/base_spec.rb
+++ b/spec/ajax-datatables-rails/base_spec.rb
@@ -181,6 +181,7 @@ RSpec.describe AjaxDatatablesRails::Base do
         data = datatable.as_json
         expect(data[:recordsTotal]).to eq 5
         expect(data[:recordsFiltered]).to eq 5
+        expect(data[:draw]).to eq 1
         expect(data[:data]).to be_a(Array)
         expect(data[:data].size).to eq 5
       end
@@ -192,6 +193,7 @@ RSpec.describe AjaxDatatablesRails::Base do
           data = datatable.as_json
           expect(data[:recordsTotal]).to eq 5
           expect(data[:recordsFiltered]).to eq 5
+          expect(data[:draw]).to eq 1
           expect(data[:data]).to be_a(Array)
           expect(data[:data].size).to eq 5
           expect(data[:foo]).to eq 'bar'


### PR DESCRIPTION
With server-side rendering if multiple concurrent ajax requests return out of order, a previous ajax response could end up overwriting (on the client side) a later response. Ajax datatables has a builtin solution for this. It passes a draw parameter which serves as a version (it's just a counter). If an ajax response is from a version prior to what is currently being displayed, then the result is ignored. The draw parameter is expected to be returned (casted as an integer to prevent XSS attacks) as specified by Ajax datatables here - https://datatables.net/manual/server-side#Returned-data

This PR will offer an immediate fix for out of order response rendering for all default configurations of ajax-datatables-rails.