### PR TITLE
Add support for grouped results

### DIFF
--- a/lib/ajax-datatables-rails/base.rb
+++ b/lib/ajax-datatables-rails/base.rb
@@ -137,11 +137,15 @@ module AjaxDatatablesRails
     end
 
     def records_total_count
-      fetch_records.count(:all)
+      numeric_count(fetch_records.count(:all))
     end
 
     def records_filtered_count
-      filter_records(fetch_records).count(:all)
+      numeric_count(filter_records(fetch_records).count(:all))
+    end
+
+    def numeric_count(count)
+      count.is_a?(Hash) ? count.values.size : count
     end
 
     def global_search_delimiter

--- a/spec/ajax-datatables-rails/orm/active_record_count_records_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_count_records_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe AjaxDatatablesRails::ORM::ActiveRecord do
+
+  let(:datatable) { ComplexDatatable.new(sample_params) }
+  let(:records) { User.all }
+
+  describe '#records_total_count' do
+    context 'ungrouped results' do
+      it 'returns the count' do
+        expect(datatable.send(:records_total_count)).to eq records.count
+      end
+    end
+
+    context 'grouped results' do
+      let(:datatable) { GroupedDatatable.new(sample_params) }
+
+      it 'returns the count' do
+        expect(datatable.send(:records_total_count)).to eq records.count
+      end
+    end
+  end
+
+
+  describe '#records_filtered_count' do
+    context 'ungrouped results' do
+      it 'returns the count' do
+        expect(datatable.send(:records_filtered_count)).to eq records.count
+      end
+    end
+
+    context 'grouped results' do
+      let(:datatable) { GroupedDatatable.new(sample_params) }
+
+      it 'returns the count' do
+        expect(datatable.send(:records_filtered_count)).to eq records.count
+      end
+    end
+  end
+end

--- a/spec/support/datatables/grouped_datatable_array.rb
+++ b/spec/support/datatables/grouped_datatable_array.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class GroupedDatatable < ComplexDatatable
+
+  def get_raw_records
+    User.all.group(:id)
+  end
+end


### PR DESCRIPTION
When using `.group` with ActiveRecord, `count(:all)` returns a Hash instead of a number. Each entry in the hash is keyed by the group(s) and then has the count for that group as the value. The count in this case is the number of entries NOT the sum of the values. When joining a has_many a single Model (grouped by id for example) would have a count of the number of children in the has_many.

```
{
  106119=>1,
  583542=>1,
  619501=>1,
  ...
}
```

The spec I added does not really show why someone would want to group. There's only a single model (User) available. Here's an example snippet from our production codebase that shows pulling in child aggregates into a datatable.
```
Quote
  .left_joins(:address, :customer, :job, :quote_line_items)
  .select('quotes.*')
  .select('COUNT(DISTINCT quote_line_items.id) AS item_count')
  .group(:id, 'customers.id', 'jobs.id', 'addresses.id')   
  # IMPORTANT: Do NOT combine into a single string expression, count(:all) can not handle a single string with multiple columns
```
