### PR TITLE
Add support for trilogy adapter for MySQL #422

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           - sqlite3
           - postgresql
           - mysql2
+          - trilogy
           - oracle_enhanced
 
     steps:
@@ -85,7 +86,7 @@ jobs:
 
         # See: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#mysql
         run: |
-          if [ "${DB_ADAPTER}" = "mysql2" ]; then
+          if [ "${DB_ADAPTER}" = "mysql2" ] || [ "${DB_ADAPTER}" = "trilogy" ]; then
             sudo systemctl start mysql.service
             mysql -u root -proot -e 'create database ajax_datatables_rails;'
           fi

--- a/appraisal.yml
+++ b/appraisal.yml
@@ -6,6 +6,9 @@
   mysql2:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "mysql2" }'
+  activerecord-trilogy-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "trilogy" }'
   activerecord-oracle_enhanced-adapter:
     version: ~> 6.0.0
     install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'
@@ -23,6 +26,9 @@
   mysql2:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "mysql2" }'
+  activerecord-trilogy-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "trilogy" }'
   activerecord-oracle_enhanced-adapter:
     version: ~> 6.1.0
     install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'
@@ -40,6 +46,9 @@
   mysql2:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "mysql2" }'
+  activerecord-trilogy-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "trilogy" }'
   activerecord-oracle_enhanced-adapter:
     version: ~> 7.0.0
     install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'

--- a/appraisal.yml
+++ b/appraisal.yml
@@ -66,6 +66,9 @@
   mysql2:
     version: ''
     install_if: '-> { ENV["DB_ADAPTER"] == "mysql2" }'
+  activerecord-trilogy-adapter:
+    version: ''
+    install_if: '-> { ENV["DB_ADAPTER"] == "trilogy" }'
   # activerecord-oracle_enhanced-adapter:
   #   version: ~> 7.0.0
   #   install_if: '-> { ENV["DB_ADAPTER"] == "oracle_enhanced" }'

--- a/gemfiles/rails_6.0.6.gemfile
+++ b/gemfiles/rails_6.0.6.gemfile
@@ -13,6 +13,10 @@ install_if -> { ENV["DB_ADAPTER"] == "mysql2" } do
   gem "mysql2"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "trilogy" } do
+  gem "activerecord-trilogy-adapter"
+end
+
 install_if -> { ENV["DB_ADAPTER"] == "oracle_enhanced" } do
   gem "activerecord-oracle_enhanced-adapter", "~> 6.0.0"
   gem "ruby-oci8"

--- a/gemfiles/rails_6.1.7.gemfile
+++ b/gemfiles/rails_6.1.7.gemfile
@@ -13,6 +13,10 @@ install_if -> { ENV["DB_ADAPTER"] == "mysql2" } do
   gem "mysql2"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "trilogy" } do
+  gem "activerecord-trilogy-adapter"
+end
+
 install_if -> { ENV["DB_ADAPTER"] == "oracle_enhanced" } do
   gem "activerecord-oracle_enhanced-adapter", "~> 6.1.0"
   gem "ruby-oci8"

--- a/gemfiles/rails_7.0.8.gemfile
+++ b/gemfiles/rails_7.0.8.gemfile
@@ -13,6 +13,10 @@ install_if -> { ENV["DB_ADAPTER"] == "mysql2" } do
   gem "mysql2"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "trilogy" } do
+  gem "activerecord-trilogy-adapter"
+end
+
 install_if -> { ENV["DB_ADAPTER"] == "oracle_enhanced" } do
   gem "activerecord-oracle_enhanced-adapter", "~> 7.0.0"
   gem "ruby-oci8"

--- a/gemfiles/rails_7.1.0.gemfile
+++ b/gemfiles/rails_7.1.0.gemfile
@@ -13,6 +13,10 @@ install_if -> { ENV["DB_ADAPTER"] == "mysql2" } do
   gem "mysql2"
 end
 
+install_if -> { ENV["DB_ADAPTER"] == "trilogy" } do
+  gem "activerecord-trilogy-adapter"
+end
+
 install_if -> { ENV["DB_ADAPTER"] == "postgis" } do
   gem "activerecord-postgis-adapter"
 end

--- a/lib/ajax-datatables-rails/datatable/column.rb
+++ b/lib/ajax-datatables-rails/datatable/column.rb
@@ -68,6 +68,7 @@ module AjaxDatatablesRails
       DB_ADAPTER_TYPE_CAST = {
         mysql:           TYPE_CAST_MYSQL,
         mysql2:          TYPE_CAST_MYSQL,
+        trilogy:         TYPE_CAST_MYSQL,
         sqlite:          TYPE_CAST_SQLITE,
         sqlite3:         TYPE_CAST_SQLITE,
         oracle:          TYPE_CAST_ORACLE,

--- a/lib/ajax-datatables-rails/datatable/simple_order.rb
+++ b/lib/ajax-datatables-rails/datatable/simple_order.rb
@@ -47,7 +47,7 @@ module AjaxDatatablesRails
         case @adapter
         when :pg, :postgresql, :postgres, :oracle, :postgis
           'NULLS LAST'
-        when :mysql, :mysql2, :sqlite, :sqlite3
+        when :mysql, :mysql2, :trilogy, :sqlite, :sqlite3
           'IS NULL'
         else
           raise "unsupported database adapter: #{@adapter}"

--- a/spec/ajax-datatables-rails/datatable/column_spec.rb
+++ b/spec/ajax-datatables-rails/datatable/column_spec.rb
@@ -188,6 +188,11 @@ RSpec.describe AjaxDatatablesRails::Datatable::Column do
       expect(column.send(:type_cast)).to eq('CHAR')
     end
 
+    it 'returns CHAR if :db_adapter is :trilogy' do
+      expect(datatable).to receive(:db_adapter) { :trilogy }
+      expect(column.send(:type_cast)).to eq('CHAR')
+    end
+
     it 'returns CHAR if :db_adapter is :mysql' do
       expect(datatable).to receive(:db_adapter) { :mysql }
       expect(column.send(:type_cast)).to eq('CHAR')

--- a/spec/ajax-datatables-rails/orm/active_record_filter_records_spec.rb
+++ b/spec/ajax-datatables-rails/orm/active_record_filter_records_spec.rb
@@ -202,6 +202,16 @@ RSpec.describe AjaxDatatablesRails::ORM::ActiveRecord do
             )
           end
         end
+
+        context 'when db_adapter is trilogy' do
+          it 'can call #to_sql on returned object' do
+            result = datatable.build_conditions_for_selected_columns
+            expect(result).to respond_to(:to_sql)
+            expect(result.to_sql).to eq(
+              "CAST(`users`.`username` AS CHAR) LIKE '%doe%' AND CAST(`users`.`email` AS CHAR) LIKE '%example%'"
+            )
+          end
+        end
       end
     end
 

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -14,6 +14,11 @@ test:
   port: 3306
   username: 'root'
   password: 'root'
+<% elsif adapter == 'trilogy' %>
+  host: '127.0.0.1'
+  port: 3306
+  username: 'root'
+  password: 'root'
 <% elsif adapter == 'oracle_enhanced' %>
   host: '127.0.0.1/xe'
   username: <%= ENV.fetch('USER') %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,7 @@ class RunningSpec
   end
 
   def self.mysql?
-    ENV['DB_ADAPTER'] == 'mysql2'
+    ENV['DB_ADAPTER'] == 'mysql2' || ENV['DB_ADAPTER'] == 'trilogy'
   end
 
   def self.postgresql?

--- a/spec/support/helpers/params.rb
+++ b/spec/support/helpers/params.rb
@@ -72,7 +72,7 @@ def nulls_last_sql(datatable)
   case datatable.db_adapter
   when :pg, :postgresql, :postgres, :oracle, :postgis
     'NULLS LAST'
-  when :mysql, :mysql2, :sqlite, :sqlite3
+  when :mysql, :mysql2, :trilogy, :sqlite, :sqlite3
     'IS NULL'
   else
     raise 'unsupported database adapter'


### PR DESCRIPTION
Adds support for trilogy [adapter](https://github.com/trilogy-libraries/activerecord-trilogy-adapter) in Rails >= 6 and <= 7.0.

Rails 7.1 includes trilogy as a built-in adapter and makes it default in Rails 8 - https://github.com/rails/rails/pull/47880, https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released